### PR TITLE
修复msg_coder库数据长度不足的bug

### DIFF
--- a/Mods/inc/msg_coder.hpp
+++ b/Mods/inc/msg_coder.hpp
@@ -20,7 +20,6 @@ typedef struct
 class UartMsgCoder
 {
 private:
-    void SetFrameParam(uint8_t Frame_Head, uint8_t Frame_Type, uint8_t *Data, int data_len, uint8_t Frame_Tail);
 
 public:
     UartMsgCoder() {};
@@ -33,6 +32,7 @@ public:
     /**      初始化     **/
     void Init(UART_HandleTypeDef *huart);
     uint8_t CalculateFrameHead(uint8_t *data, int data_len);
+    void SetFrameParam(uint8_t Frame_Head, uint8_t Frame_Type, uint8_t *Data, int data_len, uint8_t Frame_Tail);
 
     /**     消息编码与解码  	**/
     int Encode(uint8_t *buf);

--- a/Mods/src/msg_coder.cpp
+++ b/Mods/src/msg_coder.cpp
@@ -155,7 +155,7 @@ bool UartMsgCoder::SendEncodedMsg(uint8_t *encoded_data, int length)
  * @brief 发送消息（自动编码并发送）
  * @param frame_type 帧类型
  * @param data 数据指针
- * @param data_len 数据长度
+ * @param data_len 数据长度（最大为64）
  * @return 发送成功返回 true，失败返回 false
  */
 bool UartMsgCoder::SendMsg(uint8_t frame_type, uint8_t *data, int data_len)


### PR DESCRIPTION
修复msg_coder库数据长度不足的bug：正常情况下最大数据长度为64，而不是32