### PR TITLE
补充 SPI 读取链路并完善系统调度

### DIFF
--- a/ReactorLibs/Config.cpp
+++ b/ReactorLibs/Config.cpp
@@ -8,18 +8,18 @@
 void Hardware::Config_Hardwares()
 {
     /**-----    配置CAN总线     -----**/
-    Hardware::hcan_main = reinterpret_cast<BSP::CAN::CanID>(&hcan1);
+    Hardware::hcan_main = ToID(&hcan1);
     Hardware::hcan_sub = nullptr;
-
+ 
     /**-----    配置串口    -----**/
-    Hardware::huart_host = reinterpret_cast<BSP::UART::UartID>(&huart1);
-    Hardware::huart_farcon = reinterpret_cast<BSP::UART::UartID>(&huart3);
-    Hardware::huart_odom = reinterpret_cast<BSP::UART::UartID>(&huart6);
+    Hardware::huart_host = ToID(&huart1);
+    Hardware::huart_farcon = ToID(&huart3);
+    Hardware::huart_odom = ToID(&huart6);
     Hardware::huart_other = nullptr;
-
+ 
     /**-----    配置SPI总线    -----**/
     Hardware::spi_main_bus = nullptr;
-    Hardware::spi_imu_bus = nullptr;
+    Hardware::spi_imu_bus = ToID(&hspi1);
     Hardware::spi_ext_bus = nullptr;
 
     /**-----    配置定时器    -----**/

--- a/ReactorLibs/FrameComponets/Bsps/bsp_system/bsp_halport.hpp
+++ b/ReactorLibs/FrameComponets/Bsps/bsp_system/bsp_halport.hpp
@@ -56,6 +56,29 @@
     #endif
 
 #endif 
+ 
+namespace BSP
+{
+    namespace CAN { struct OpaqueCan; using CanID = OpaqueCan*; }
+    namespace UART { struct OpaqueUart; using UartID = OpaqueUart*; }
+    namespace SPI { struct OpaqueSpi; using SpiID = OpaqueSpi*; }
+}
+
+// ---- 框架助手函数：将 HAL 句柄转换为框架 ID ----
+inline BSP::CAN::CanID ToID(CAN_HandleTypeDef* handle)
+{
+    return reinterpret_cast<BSP::CAN::CanID>(handle);
+}
+
+inline BSP::UART::UartID ToID(UART_HandleTypeDef* handle)
+{
+    return reinterpret_cast<BSP::UART::UartID>(handle);
+}
+
+inline BSP::SPI::SpiID ToID(SPI_HandleTypeDef* handle)
+{
+    return reinterpret_cast<BSP::SPI::SpiID>(handle);
+}
 
 
 namespace Hardware

--- a/ReactorLibs/FrameComponets/Bsps/bsp_system/std_cpp.h
+++ b/ReactorLibs/FrameComponets/Bsps/bsp_system/std_cpp.h
@@ -24,6 +24,9 @@ void ApplicationCpp();
 /// @brief 机器人主任务
 void RobotSystemCpp();
 
+/// @brief SPI读取任务
+void SpiReadCpp();
+
 /// @brief 测试任务
 void TestCpp();
 

--- a/ReactorLibs/FrameComponets/Bsps/dwt/bsp_dwt.cpp
+++ b/ReactorLibs/FrameComponets/Bsps/dwt/bsp_dwt.cpp
@@ -15,6 +15,39 @@ static uint32_t CYCCNT_LAST;
 static uint64_t CYCCNT64;
 
 /**
+ * @brief 将等待时间换算成CYCCNT tick，并限制在单圈32位差值可表达的范围内
+ * @note DWT_Delay / DWT_DelayMs 内部都是通过 `(uint32_t)(now - start)` 来判断是否到时
+ *       这种写法只在“目标tick数不超过 uint32_t 一整圈”时成立
+ *       因此这里统一做两件事：
+ *       1. 非法或非正数参数直接按0处理，避免无意义等待
+ *       2. 超过单圈上限时钳制到 UINT32_MAX，避免比较目标超过可达范围后死循环
+ *
+ * @param wait 输入等待值，单位由 cpu_freq 决定
+ * @param cpu_freq 对应单位下每秒/每毫秒的tick频率
+ * @return uint32_t 可安全用于32位差值比较的等待tick数
+ */
+static uint32_t DWT_GetWaitTicks(double wait, uint32_t cpu_freq)
+{
+    // 小于等于0的等待没有实际意义，直接返回0 tick
+    if (wait <= 0.0)
+    {
+        return 0u;
+    }
+
+    // 使用double先做乘法，避免float在大数区间过早损失精度
+    double wait_ticks = wait * (double)cpu_freq;
+
+    // 目标tick超过32位单圈差值的表达范围时，钳到最大安全值
+    if (wait_ticks >= (double)UINT32_MAX)
+    {
+        return UINT32_MAX;
+    }
+
+    // 这里保留向下取整语义，保证实际等待不会因为进位而越过请求上界
+    return (uint32_t)wait_ticks;
+}
+
+/**
  * @brief 用于检查DWT CYCCNT寄存器是否溢出,并更新CYCCNT_RountCount
  * @attention 此函数假设两次调用之间的时间间隔不超过一次溢出
  *
@@ -163,11 +196,24 @@ uint64_t DWT_GetTimeline_USec(void)
     return DWT_Timelinef32;
 }
 
-void DWT_Delay(float Delay)
+void DWT_Delay(float Sec)
 {
     uint32_t tickstart = DWT->CYCCNT;
-    float wait = Delay;
+    // 先把秒换算成安全的tick目标，避免在while里重复做浮点乘法和隐式类型比较
+    uint32_t wait_ticks = DWT_GetWaitTicks((double)Sec, CPU_FREQ_Hz);
 
-    while ((DWT->CYCCNT - tickstart) < wait * (float)CPU_FREQ_Hz)
+    // 这里依赖uint32_t减法回绕特性做忙等待，但前提是 wait_ticks 不超过单圈上限
+    while ((uint32_t)(DWT->CYCCNT - tickstart) < wait_ticks)
+        ;
+}
+
+void DWT_DelayMs(float MilSec)
+{
+    uint32_t tickstart = DWT->CYCCNT;
+    // 毫秒版本与秒版本保持同一套安全策略，只是换算频率改为每毫秒tick数
+    uint32_t wait_ticks = DWT_GetWaitTicks((double)MilSec, CPU_FREQ_Hz_ms);
+
+    // 纯uint32_t比较可避免把float精度问题带进循环条件
+    while ((uint32_t)(DWT->CYCCNT - tickstart) < wait_ticks)
         ;
 }

--- a/ReactorLibs/FrameComponets/Bsps/dwt/bsp_dwt.hpp
+++ b/ReactorLibs/FrameComponets/Bsps/dwt/bsp_dwt.hpp
@@ -93,10 +93,24 @@ uint64_t DWT_GetTimeline_USec(void);
  * @brief DWT延时函数,单位为秒/s
  * @attention 该函数不受中断是否开启的影响,可以在临界区和关闭中断时使用
  * @note 禁止在__disable_irq()和__enable_irq()之间使用HAL_Delay()函数,应使用本函数
+ * @note 单次等待内部使用32位CYCCNT差值计数,最大只支持不超过一整圈计数器的等待
+ *       超过上限时会被钳制到最大可等待值,避免比较溢出后死循环
+ *       A板(180MHz)建议Sec <= 23.8f, C板(168MHz)建议Sec <= 25.5f
  *
- * @param Delay 延时时间,单位为秒/s
+ * @param Sec 延时时间,单位为秒/s
  */
-void DWT_Delay(float Delay);
+void DWT_Delay(float Sec);
+
+/**
+ * @brief DWT延时函数,单位为毫秒/ms
+ * @attention 该函数不受中断是否开启的影响,可以在临界区和关闭中断时使用
+ * @note 单次等待内部使用32位CYCCNT差值计数,最大只支持不超过一整圈计数器的等待
+ *       超过上限时会被钳制到最大可等待值,避免比较溢出后死循环
+ *       A板(180MHz)建议MilSec <= 23800.0f, C板(168MHz)建议MilSec <= 25500.0f
+ *
+ * @param MilSec 延时时间,单位为毫秒/ms
+ */
+void DWT_DelayMs(float MilSec);
 
 /**
  * @brief DWT更新时间轴函数,会被三个timeline函数调用

--- a/ReactorLibs/FrameComponets/Bsps/dwt/bsp_dwt.hpp
+++ b/ReactorLibs/FrameComponets/Bsps/dwt/bsp_dwt.hpp
@@ -16,11 +16,6 @@
 
 #include "bsp_halport.hpp"
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #define CPU_HERT_A_BOARD_MHZ 180
 #define CPU_HERT_C_BOARD_MHZ 168
 
@@ -125,7 +120,5 @@ void DWT_SysTimeUpdate(void);
  */
 void DWT_CntUpdate(void);
 
-#ifdef __cplusplus
-}
-#endif
+
 #endif /* BSP_DWT_H_ */

--- a/ReactorLibs/FrameComponets/Bsps/gpio/bsp_gpio.hpp
+++ b/ReactorLibs/FrameComponets/Bsps/gpio/bsp_gpio.hpp
@@ -2,9 +2,7 @@
 #define BSP_GPIO_H
 #include "bsp_halport.hpp"
 
-#ifdef __cplusplus
-extern "C"{
-#endif
+
 
 #define BSPGPIO_MAX_INSTS 140 // 最多支持140个GPIO实例
 
@@ -36,7 +34,5 @@ static uint8_t BspGpio_GetPinIndex(uint16_t GPIO_Pin);
 
 
 
-#ifdef __cplusplus
-}
-#endif
+
 #endif

--- a/ReactorLibs/FrameComponets/Bsps/log/bsp_log.hpp
+++ b/ReactorLibs/FrameComponets/Bsps/log/bsp_log.hpp
@@ -1,10 +1,6 @@
 #pragma once
 #include "bsp_halport.hpp"
 
-#ifdef __cplusplus
-extern "C"{
-#endif
-
 typedef void (*cmd_handler_t)(int argc, char **argv);
 
 
@@ -31,6 +27,3 @@ extern void BspLog_LogRespond(const char* fmt, ...);
 
 extern void BspLog_RegistCMD(const char* name, cmd_handler_t handler, const char* help);
 
-#ifdef __cplusplus
-}
-#endif

--- a/ReactorLibs/FrameComponets/Bsps/pwm/bsp_tim_pwm.hpp
+++ b/ReactorLibs/FrameComponets/Bsps/pwm/bsp_tim_pwm.hpp
@@ -2,11 +2,6 @@
 #define BSP_TIM_PWM_H
 #include "bsp_halport.hpp"
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 typedef struct BspTIMPWM_t
 {
     TIM_HandleTypeDef *htim;        // PWM定时器句柄
@@ -27,9 +22,5 @@ void BspTIMPWM_InstRegist(BspTIMPWM_TypeDef *tim_inst, TIM_HandleTypeDef *htim, 
 void BspTIMPWM_SetDuty(BspTIMPWM_TypeDef *tim_inst, float duty);
 void BspTIMPWM_Enable(BspTIMPWM_TypeDef *tim_inst);
 void BspTIMPWM_Disable(BspTIMPWM_TypeDef *tim_inst);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/ReactorLibs/FrameComponets/Bsps/spi/bsp_spi.cpp
+++ b/ReactorLibs/FrameComponets/Bsps/spi/bsp_spi.cpp
@@ -457,19 +457,24 @@ bool Device::TransRecvDMA(uint8_t *tx_data, uint8_t *rx_data, uint16_t size)
  */
 DmaState Device::ConsumeDmaState()
 {
-    // 仅DMA owner可以读取并消费最终态，其他设备始终视为Idle
+    // 确认当前想读这个的设备，是DMA的owner；否则判定为其他设备，始终视为Idle
     if (GetDmaOwnerDevice(this->spi_id) != this)
     {
         return DmaState::Idle;
     }
 
+    // 读取状态
     DmaState state = GetDmaState(this->spi_id);
+    
+    // 只有owner设备能看到Done/Error状态
+    // 一旦看到就消费掉，复位为Idle并释放owner
     if (state == DmaState::Done || state == DmaState::Error)
     {
         // Done/Error为一次性事件：消费后复位为Idle并释放owner
         SetDmaState(this->spi_id, DmaState::Idle);
         SetDmaOwnerDevice(this->spi_id, nullptr);
     }
+
     return state;
 }
 

--- a/ReactorLibs/FrameComponets/Bsps/stdmath/std_math.cpp
+++ b/ReactorLibs/FrameComponets/Bsps/stdmath/std_math.cpp
@@ -197,3 +197,46 @@ int StdMath::signf(float val)
     else if (val < 0)   return -1;
     else return 0;
 }
+
+///////////////////////////////////////////          QUAT         /////////////////////////////////////////////////////
+/*********      Quat 归一化      **********/
+void Quat::Normalize()
+{
+    float magnitude = sqrt(this->w * this->w + this->x * this->x + this->y * this->y + this->z * this->z);
+    if (magnitude > 0.0f)
+    {
+        this->w /= magnitude;
+        this->x /= magnitude;
+        this->y /= magnitude;
+        this->z /= magnitude;
+    }
+}
+
+/*********      Quat 转欧拉角      **********/
+Vec3 Quat::ToEuler() const
+{
+    Vec3 euler;
+    
+    // Roll (x-axis rotation)
+    float sinr_cosp = 2.0f * (this->w * this->x + this->y * this->z);
+    float cosr_cosp = 1.0f - 2.0f * (this->x * this->x + this->y * this->y);
+    euler.x = atan2(sinr_cosp, cosr_cosp);
+
+    // Pitch (y-axis rotation)
+    float sinp = 2.0f * (this->w * this->y - this->z * this->x);
+    if (fabs(sinp) >= 1.0f)
+    {
+        euler.y = copysign(3.14159265358979323846f / 2.0f, sinp); // use 90 degrees if out of range
+    }
+    else
+    {
+        euler.y = asin(sinp);
+    }
+
+    // Yaw (z-axis rotation)
+    float siny_cosp = 2.0f * (this->w * this->z + this->x * this->y);
+    float cosy_cosp = 1.0f - 2.0f * (this->y * this->y + this->z * this->z);
+    euler.z = atan2(siny_cosp, cosy_cosp);
+
+    return euler;
+}

--- a/ReactorLibs/FrameComponets/Bsps/stdmath/std_math.hpp
+++ b/ReactorLibs/FrameComponets/Bsps/stdmath/std_math.hpp
@@ -216,6 +216,33 @@ inline Color operator/(const Color &vec, float scalar)
   return Color(vec.r / scalar, vec.g / scalar, vec.b / scalar);
 }
 
+/**
+ * @name 四元数
+ */
+class Quat
+{
+public:
+  float w, x, y, z;
+  Quat(float w = 1.0f, float x = 0.0f, float y = 0.0f, float z = 0.0f) : w(w), x(x), y(y), z(z)
+  {
+  }
+
+  void Normalize();
+  Vec3 ToEuler() const;
+
+  friend Quat operator*(const Quat &lhs, const Quat &rhs);
+};
+
+/*********      运算符重载      **********/
+inline Quat operator*(const Quat &lhs, const Quat &rhs)
+{
+  return Quat(
+      lhs.w * rhs.w - lhs.x * rhs.x - lhs.y * rhs.y - lhs.z * rhs.z,
+      lhs.w * rhs.x + lhs.x * rhs.w + lhs.y * rhs.z - lhs.z * rhs.y,
+      lhs.w * rhs.y - lhs.x * rhs.z + lhs.y * rhs.w + lhs.z * rhs.x,
+      lhs.w * rhs.z + lhs.x * rhs.y - lhs.y * rhs.x + lhs.z * rhs.w);
+}
+
 typedef struct
 {
   int id;

--- a/ReactorLibs/FrameComponets/Mods/relay/relay.hpp
+++ b/ReactorLibs/FrameComponets/Mods/relay/relay.hpp
@@ -1,15 +1,7 @@
 #ifndef RELAY_HPP
 #define RELAY_HPP
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "bsp_gpio.hpp"
-
-#ifdef __cplusplus
-}
-#endif
 
 // 继电器类
 class Relay

--- a/ReactorLibs/FrameComponets/Sys/Monitor/Monitor.hpp
+++ b/ReactorLibs/FrameComponets/Sys/Monitor/Monitor.hpp
@@ -161,4 +161,10 @@ public:
     void TrackLogJustFloat();
 };
 
+/**
+ * @brief 全局监视器别名
+ * @note 只允许在一个 .cpp 中定义，其他地方通过 extern 共享
+ */
+extern Monitor &monit;
+
 #endif

--- a/ReactorLibs/FrameComponets/Sys/System/RtosCpp.cpp
+++ b/ReactorLibs/FrameComponets/Sys/System/RtosCpp.cpp
@@ -4,6 +4,7 @@
 #include "freertos.h"
 #include "task.h"
 #include "cmsis_os.h"
+#include "semphr.h"
 
 #include "bsp_dwt.hpp"
 #include "motor_dji.hpp"
@@ -17,10 +18,18 @@
 TaskHandle_t ApplicationTaskHandle;
 TaskHandle_t RobotSystemTaskHandle;
 TaskHandle_t SpiReadTaskHandle;
+TaskHandle_t SpiConsumeTaskHandle;
 TaskHandle_t ControlTaskHandle;
 TaskHandle_t StateCoreTaskHandle;
 TaskHandle_t CoroutineHandles[4]; // 协程数组，管理更方便
+static SemaphoreHandle_t SpiConsumeSemaphore = nullptr;
 void Reactor46H_TakeOverRTOS();
+void ApplicationCpp();
+void RobotSystemCpp();
+void StateCoreCpp();
+void ControlCpp();
+void SpiReadCpp();
+void SpiConsumeCpp();
 
 
 /* ================= 内部适配器 ================= */
@@ -69,6 +78,13 @@ void Reactor46H_Initialize()
  */
 void Reactor46H_TakeOverRTOS()
 {
+    // SPI 消费线程平时阻塞在这个二值信号量上。
+    // 读线程只负责“叫醒它”，不直接承担消费算法。
+    if (SpiConsumeSemaphore == nullptr)
+    {
+        SpiConsumeSemaphore = xSemaphoreCreateBinary();
+    }
+
     xTaskCreate(TaskWrapper, "Control", 256, (void*)ControlCpp, 
                 osPriorityAboveNormal, &ControlTaskHandle);
 
@@ -77,6 +93,9 @@ void Reactor46H_TakeOverRTOS()
 
     xTaskCreate(TaskWrapper, "SpiRead", 128, (void*)SpiReadCpp, 
                 osPriorityBelowNormal, &SpiReadTaskHandle);
+
+    xTaskCreate(TaskWrapper, "SpiConsume", 256, (void*)SpiConsumeCpp,
+                osPriorityNormal, &SpiConsumeTaskHandle);
 
     xTaskCreate(TaskWrapper, "App", 512, (void*)ApplicationCpp, 
                 osPriorityNormal, &ApplicationTaskHandle);
@@ -90,6 +109,16 @@ void Reactor46H_TakeOverRTOS()
     //     xTaskCreate(CoroutineStub, "Coroutine", 128, NULL, 
     //                 tskIDLE_PRIORITY + 1, &CoroutineHandles[i]);
     // }
+}
+
+void Reactor46H_NotifySpiConsume()
+{
+    // 这里只做最直接的唤醒，不在这里判断是谁的新数据。
+    // 被唤醒后，消费线程会自己把各实例邮箱里的样本全部吃完。
+    if (SpiConsumeSemaphore != nullptr)
+    {
+        xSemaphoreGive(SpiConsumeSemaphore);
+    }
 }
 
 /**
@@ -176,5 +205,19 @@ void SpiReadCpp()
     {
         System._Update_SpiSamps();
         osDelayUntil(&AppTick, 2);
+    }
+}
+
+void SpiConsumeCpp()
+{
+    while (1)
+    {
+        // 平时阻塞等待；一旦有任意 SpiSamp 产出了完整新帧，就起来把当前可消费样本全部处理掉。
+        if (SpiConsumeSemaphore != nullptr)
+        {
+            xSemaphoreTake(SpiConsumeSemaphore, portMAX_DELAY);
+        }
+
+        System._Update_SpiConsumes();
     }
 }

--- a/ReactorLibs/FrameComponets/Sys/System/RtosCpp.cpp
+++ b/ReactorLibs/FrameComponets/Sys/System/RtosCpp.cpp
@@ -170,10 +170,11 @@ void ControlCpp()
  */
 void SpiReadCpp()
 {
+    uint32_t AppTick = xTaskGetTickCount();
+
     while (1)
     {
-        
-        /***    最大循环频率：500Hz     ***/
-        osDelay(2); // 500Hz
+        System._Update_SpiSamps();
+        osDelayUntil(&AppTick, 2);
     }
 }

--- a/ReactorLibs/FrameComponets/Sys/System/RtosCpp.cpp
+++ b/ReactorLibs/FrameComponets/Sys/System/RtosCpp.cpp
@@ -16,6 +16,7 @@
 // 如果需要在其他地方引用（如挂起任务），可以在头文件 extern
 TaskHandle_t ApplicationTaskHandle;
 TaskHandle_t RobotSystemTaskHandle;
+TaskHandle_t SpiReadTaskHandle;
 TaskHandle_t ControlTaskHandle;
 TaskHandle_t StateCoreTaskHandle;
 TaskHandle_t CoroutineHandles[4]; // 协程数组，管理更方便
@@ -73,6 +74,9 @@ void Reactor46H_TakeOverRTOS()
 
     xTaskCreate(TaskWrapper, "RobotSys", 256, (void*)RobotSystemCpp, 
                 osPriorityNormal, &RobotSystemTaskHandle);
+
+    xTaskCreate(TaskWrapper, "SpiRead", 128, (void*)SpiReadCpp, 
+                osPriorityBelowNormal, &SpiReadTaskHandle);
 
     xTaskCreate(TaskWrapper, "App", 512, (void*)ApplicationCpp, 
                 osPriorityNormal, &ApplicationTaskHandle);
@@ -156,5 +160,20 @@ void ControlCpp()
         System.PerformanceRun();
         /***    最大循环频率：1000Hz     ***/
         osDelay(1); // FreeRTOS的极限，1ms喂狗
+    }
+}
+
+
+/**
+ * @brief 读取SPI数据的任务
+ * 
+ */
+void SpiReadCpp()
+{
+    while (1)
+    {
+        
+        /***    最大循环频率：500Hz     ***/
+        osDelay(2); // 500Hz
     }
 }

--- a/ReactorLibs/FrameComponets/Sys/System/RtosCpp.hpp
+++ b/ReactorLibs/FrameComponets/Sys/System/RtosCpp.hpp
@@ -3,3 +3,6 @@
 
 __weak void MainFrameCpp(){};
 
+/// @brief 通知 SPI 消费线程：有新的完整样本可以处理了。
+/// @note 这里只暴露一个最小的唤醒接口，System 层不需要知道底层信号量细节。
+void Reactor46H_NotifySpiConsume();

--- a/ReactorLibs/FrameComponets/Sys/System/System.cpp
+++ b/ReactorLibs/FrameComponets/Sys/System/System.cpp
@@ -8,6 +8,7 @@
 #include "bsp_log.hpp"
 #include "freertos.h"
 #include "task.h"
+#include "RtosCpp.hpp"
 
 SystemType& System = SystemType::GetInstance();
 LedWs2812 sys_ledband;
@@ -413,8 +414,31 @@ void SystemType::_Update_SpiSamps()
 
         if (sampler->poll_full_frame == nullptr) continue;
 
-        // 与 App 类似，按循环节拍直接轮询
-        sampler->poll_full_frame(sampler->owner);
+        // 与 App 类似，按循环节拍直接轮询。
+        // 一旦这一轮确实产出了完整新帧，并且实例声明了消费回调，
+        // 就立刻唤醒消费线程，避免把算法耗时塞进 SpiRead 线程。
+        bool has_new_frame = sampler->poll_full_frame(sampler->owner);
+        if (has_new_frame && sampler->consume_full_frame != nullptr)
+        {
+            Reactor46H_NotifySpiConsume();
+        }
+    }
+}
+
+void SystemType::_Update_SpiConsumes()
+{
+    for (uint8_t i = 0; i < 24; i++)
+    {
+        SpiSamp *sampler = spi_sampler_list[i];
+
+        if (sampler == nullptr) continue;
+        if (sampler->consume_full_frame == nullptr) continue;
+
+        // 一次唤醒就把实例内部已经准备好的样本全部消费掉。
+        // 这样 System 只管“唤醒”，不需要在系统层维护额外的样本队列状态。
+        while (sampler->consume_full_frame(sampler->owner))
+        {
+        }
     }
 }
 

--- a/ReactorLibs/FrameComponets/Sys/System/System.cpp
+++ b/ReactorLibs/FrameComponets/Sys/System/System.cpp
@@ -6,6 +6,8 @@
 #include "Monitor.hpp"
 #include "farcon.hpp"
 #include "bsp_log.hpp"
+#include "freertos.h"
+#include "task.h"
 
 SystemType& System = SystemType::GetInstance();
 LedWs2812 sys_ledband;
@@ -372,6 +374,49 @@ bool SystemType::RegistApp(Application &app_inst)
     return false;
 }
 
+bool SystemType::RegistSpiSamp(SpiSamp &sampler)
+{
+    // 回调为空时不允许注册
+    if (sampler.poll_full_frame == nullptr)
+    {
+        BspLog_LogWarning("SpiSamp [%s] register failed: empty callback.\n",
+                          (sampler.name != nullptr) ? sampler.name : "Unknown");
+        return false;
+    }
+
+    // 查找空槽并注册
+    for (uint8_t i = 0; i < 24; i++)
+    {
+        if (spi_sampler_list[i] == nullptr)
+        {
+            spi_sampler_list[i] = &sampler;
+            return true;
+        }
+    }
+
+    BspLog_LogWarning("SpiSamp [%s] register failed: list full.\n",
+                      (sampler.name != nullptr) ? sampler.name : "Unknown");
+    return false;
+}
+
+/**
+ * @brief 更新所有 SPI 采样器（轮询模式）
+ */
+void SystemType::_Update_SpiSamps()
+{
+    for (uint8_t i = 0; i < 24; i++)
+    {
+        // 获取对应的采样器实例
+        SpiSamp *sampler = spi_sampler_list[i];
+
+        // 确保实例存在
+        if (sampler == nullptr) continue;
+
+        // 与 App 类似，按循环节拍直接轮询
+        sampler->poll_full_frame(sampler->ctx);
+    }
+}
+
 /**
  * @brief 运行所有应用实例并更新健康状态缓存
  */
@@ -405,5 +450,3 @@ bool Application::CntFull()
     }
     return false;
 }
-
-

--- a/ReactorLibs/FrameComponets/Sys/System/System.cpp
+++ b/ReactorLibs/FrameComponets/Sys/System/System.cpp
@@ -376,10 +376,9 @@ bool SystemType::RegistApp(Application &app_inst)
 
 bool SystemType::RegistSpiSamp(SpiSamp &sampler)
 {
-    // 回调为空时不允许注册
     if (sampler.poll_full_frame == nullptr)
     {
-        BspLog_LogWarning("SpiSamp [%s] register failed: empty callback.\n",
+        BspLog_LogWarning("SpiSamp [%s] register failed: callback is null.\n",
                           (sampler.name != nullptr) ? sampler.name : "Unknown");
         return false;
     }
@@ -412,8 +411,10 @@ void SystemType::_Update_SpiSamps()
         // 确保实例存在
         if (sampler == nullptr) continue;
 
+        if (sampler->poll_full_frame == nullptr) continue;
+
         // 与 App 类似，按循环节拍直接轮询
-        sampler->poll_full_frame(sampler->ctx);
+        sampler->poll_full_frame(sampler->owner);
     }
 }
 

--- a/ReactorLibs/FrameComponets/Sys/System/System.hpp
+++ b/ReactorLibs/FrameComponets/Sys/System/System.hpp
@@ -53,6 +53,7 @@ struct SpiSamp
     const char* name = "SpiSamp";               // 采样器名称，仅用于日志定位
     void* owner = nullptr;                      // 采样器所属对象
     bool (*poll_full_frame)(void* owner) = nullptr;
+    bool (*consume_full_frame)(void* owner) = nullptr; // 可选的消费回调：读线程产出样本后，由消费线程尽快处理
 };
 
 class Application
@@ -109,6 +110,7 @@ class SystemType
     friend void ApplicationCpp();
     friend void StateCoreCpp();
     friend void SpiReadCpp();
+    friend void SpiConsumeCpp();
 
     SINGLETON(SystemType):Display(*this){};
     
@@ -121,6 +123,7 @@ class SystemType
     void _Update_Applications();
     void _Update_SelfCheck(); 
     void _Update_SpiSamps();
+    void _Update_SpiConsumes();
 
     class _LedDisplayAPI
     {

--- a/ReactorLibs/FrameComponets/Sys/System/System.hpp
+++ b/ReactorLibs/FrameComponets/Sys/System/System.hpp
@@ -48,13 +48,11 @@ namespace App
     };
 }
 
-using SpiSampPollFn = bool (*)(void *ctx);
-
 struct SpiSamp
 {
     const char* name = "SpiSamp";               // 采样器名称，仅用于日志定位
-    SpiSampPollFn poll_full_frame = nullptr;    // 轮询回调，返回本次是否采样成功
-    void* ctx = nullptr;                           // 回调上下文
+    void* owner = nullptr;                      // 采样器所属对象
+    bool (*poll_full_frame)(void* owner) = nullptr;
 };
 
 class Application

--- a/ReactorLibs/FrameComponets/Sys/System/System.hpp
+++ b/ReactorLibs/FrameComponets/Sys/System/System.hpp
@@ -48,6 +48,15 @@ namespace App
     };
 }
 
+using SpiSampPollFn = bool (*)(void *ctx);
+
+struct SpiSamp
+{
+    const char* name = "SpiSamp";               // 采样器名称，仅用于日志定位
+    SpiSampPollFn poll_full_frame = nullptr;    // 轮询回调，返回本次是否采样成功
+    void* ctx = nullptr;                           // 回调上下文
+};
+
 class Application
 {
     friend class SystemType;            // 允许系统类访问私有成员
@@ -101,6 +110,7 @@ class SystemType
     friend void RobotSystemCpp();
     friend void ApplicationCpp();
     friend void StateCoreCpp();
+    friend void SpiReadCpp();
 
     SINGLETON(SystemType):Display(*this){};
     
@@ -112,6 +122,7 @@ class SystemType
     void _Update_LedBand();
     void _Update_Applications();
     void _Update_SelfCheck(); 
+    void _Update_SpiSamps();
 
     class _LedDisplayAPI
     {
@@ -168,6 +179,7 @@ class SystemType
 
     bool is_retrying = false;                               // 是否处于重试状态（从RetryZone出发）
     Application* app_list[24];                              // 系统中的应用实例列表
+    SpiSamp* spi_sampler_list[24];                       // SPI采样实例列表
 
 
 public:
@@ -197,6 +209,8 @@ public:
     
     /// @brief 应用注册 
     bool RegistApp(Application& app_inst);
+    /// @brief SPI采样任务注册（只注册回调，不处理调度）
+    bool RegistSpiSamp(SpiSamp& sampler);
 
     /// @brief 运行机器人系统主进程
     void Run();
@@ -207,6 +221,7 @@ public:
     
     private:
     uint16_t ledband_prescaler = 4;                     // 主灯带更新预分频（200 / 4 = 50Hz）
+    
 };
 
 

--- a/ReactorLibs/MainFrame.cpp
+++ b/ReactorLibs/MainFrame.cpp
@@ -1,7 +1,7 @@
 #include "MainFrame.hpp"
 #include "Monitor.hpp"
 #include "System.hpp"
-#include "IMU_Example.hpp"
+#include "IMUOdom_Test.hpp"
 
 StateCore &core = StateCore::GetInstance();
 Monitor &monit = Monitor::GetInstance();
@@ -15,7 +15,9 @@ void Action_of_Dege(StateCore *core);
  */
 void MainFrameCpp()
 {
-  System.RegistApp(IMU_Example::GetInstance());
+  // 当前主入口默认挂载 IMU 里程计验证应用，避免多个测试同时输出。
+  IMUOdom_Test &imu_odom_test = IMUOdom_Test::GetInstance();
+  System.RegistApp(imu_odom_test);
 
   // 配置状态图为简并模式
   example_graph.Degenerate(Action_of_Dege);

--- a/ReactorLibs/Reactor46H.cmake
+++ b/ReactorLibs/Reactor46H.cmake
@@ -1,8 +1,7 @@
 # 这里的 ${PROJECT_SOURCE_DIR} 指的是CubeMX的那个 .ioc 文件所在的根目录
 # 递归寻找所有 .h 和 .hpp 文件
-# 不使用 CONFIGURE_DEPENDS，避免每次 build 前都递归重扫目录
-# 当新增/重排库文件后，手动执行一次: cmake --preset Debug
-file(GLOB_RECURSE ALL_HEADERS
+# 使用 CONFIGURE_DEPENDS，让 CMake 在文件增删后自动重新配置
+file(GLOB_RECURSE ALL_HEADERS CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_LIST_DIR}/*.h" 
     "${CMAKE_CURRENT_LIST_DIR}/*.hpp"
 )
@@ -24,9 +23,9 @@ endif()
 target_include_directories(${CMAKE_PROJECT_NAME} BEFORE PRIVATE ${REACTOR_INC})
 
 # 收集所有 .c 源文件
-file(GLOB_RECURSE REACTOR_SRCS 
-    "ReactorLibs/*.c"
-    "ReactorLibs/*.cpp"
+file(GLOB_RECURSE REACTOR_SRCS CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_LIST_DIR}/*.c"
+    "${CMAKE_CURRENT_LIST_DIR}/*.cpp"
 )
 
 # 将路径和文件添加到工程目标中

--- a/reactorlize.py
+++ b/reactorlize.py
@@ -165,7 +165,7 @@ def run_sync_keil(root: Path) -> None:
 
 
 def pull_extensions_repo(root: Path) -> None:
-    reactor_lib_dir = root / "ReactorLib"
+    reactor_lib_dir = root / "ReactorLibs"
     extensions_dir = reactor_lib_dir / "Extensions70"
 
     reactor_lib_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## PR Description
本 PR 主要围绕 SPI 数据链路与系统调度进行补充和整理，保持整体结构尽量直接。

## 主要改动：
- 新增 SPI 读取与消费线程，补上从采样到处理的基本流程
- 在 System 层增加 SpiSamp 注册、轮询与消费调度逻辑
- 优化部分 SPI DMA 状态处理细节
- 为 std_math 补充四元数相关能力
- 调整主入口默认挂载的测试应用，便于当前验证流程
- 同步了一些底层兼容性与工程配置相关的小优化

## 影响说明：
- 让 SPI 数据处理链路更完整，读取与消费职责更清晰
- 系统调度结构更适合后续继续接入 SPI 类传感器或模块
- 目前改动以功能打通和结构整理为主，整体保持轻量