### PR TITLE
一次小更新

### DIFF
--- a/ReactorLibs/FrameComponets/Sys/System/RtosCpp.cpp
+++ b/ReactorLibs/FrameComponets/Sys/System/RtosCpp.cpp
@@ -86,13 +86,13 @@ void Reactor46H_TakeOverRTOS()
     }
 
     xTaskCreate(TaskWrapper, "Control", 256, (void*)ControlCpp, 
-                osPriorityAboveNormal, &ControlTaskHandle);
+                osPriorityNormal, &ControlTaskHandle);
 
     xTaskCreate(TaskWrapper, "RobotSys", 256, (void*)RobotSystemCpp, 
                 osPriorityNormal, &RobotSystemTaskHandle);
 
     xTaskCreate(TaskWrapper, "SpiRead", 128, (void*)SpiReadCpp, 
-                osPriorityBelowNormal, &SpiReadTaskHandle);
+                osPriorityNormal, &SpiReadTaskHandle);
 
     xTaskCreate(TaskWrapper, "SpiConsume", 256, (void*)SpiConsumeCpp,
                 osPriorityNormal, &SpiConsumeTaskHandle);
@@ -101,7 +101,7 @@ void Reactor46H_TakeOverRTOS()
                 osPriorityNormal, &ApplicationTaskHandle);
 
     xTaskCreate(TaskWrapper, "StateCore", 512, (void*)StateCoreCpp, 
-                osPriorityHigh, &StateCoreTaskHandle);
+                osPriorityNormal, &StateCoreTaskHandle);
 
     // 如果你还需要原来的 4 个协程，可以用循环批量创建
     // for(int i = 0; i < 4; i++) {

--- a/ReactorLibs/FrameComponets/Sys/System/System.cpp
+++ b/ReactorLibs/FrameComponets/Sys/System/System.cpp
@@ -49,8 +49,11 @@ void SystemType::Init(bool Sc)
  */
 void SystemType::Run()
 {
-    // 自检
-    _Update_SelfCheck();
+  static float delta_time = 0;
+  static uint32_t cnt = 0;
+
+  // 自检
+  _Update_SelfCheck();
 
     /*--<       正式运行        >--*/
 
@@ -63,11 +66,27 @@ void SystemType::Run()
         position = *pos_source;
     }
 
-    // 更新全局时间
-    runtime_tick = DWT_GetTimeline_Sec();
+  // 更新全局时间
+  runtime_tick = DWT_GetTimeline_Sec();
+  delta_time = DWT_GetDeltaTime(&cnt);
 
-    // RTT接收命令处理
-    BspLog_RecvCMD();
+  // 判定计时器是否停止连续六次（30ms）
+  static uint32_t stop_cnt = 0;
+  if (delta_time < 0.002f)
+  {
+    stop_cnt++;
+    if (stop_cnt == 6)
+    {
+      monit.LogSpec("--- --- Exit of Debug Detected! --- ---\n");
+    }
+  }
+  else
+  {
+    stop_cnt = 0;
+  }
+
+  // RTT接收命令处理
+  // BspLog_RecvCMD();
 
     // 零开销巡检所有 App 状态
     for (int i = 0; i < 24; i++) {

--- a/ReactorLibs/FrameComponets/Sys/System/System.cpp
+++ b/ReactorLibs/FrameComponets/Sys/System/System.cpp
@@ -77,11 +77,13 @@ void SystemType::Run()
     stop_cnt++;
     if (stop_cnt == 6)
     {
+      out_from_debugmode = true;
       monit.LogSpec("--- --- Exit of Debug Detected! --- ---\n");
     }
   }
   else
   {
+    out_from_debugmode = false;
     stop_cnt = 0;
   }
 

--- a/ReactorLibs/FrameComponets/Sys/System/System.hpp
+++ b/ReactorLibs/FrameComponets/Sys/System/System.hpp
@@ -188,6 +188,7 @@ public:
     bool system_ready_flag = false;                  // 系统准备就绪标志位
     bool system_start_to_work_flag = false;         // 系统开始工作标志位
 
+    bool out_from_debugmode = false;
 
     /// @brief 机器人全局位置，单位m，场地坐标系
     Vec3    position;

--- a/log_router.py
+++ b/log_router.py
@@ -11,6 +11,9 @@ from colorama import init, Fore, Style
 init(autoreset=True)
 
 # ================= 配置区域 =================
+# 默认串口配置
+DEFAULT_BAUD_RATE = 921600
+
 # 是否显示每一行接收到的原始数据 (调试开关)，可通过终端动态配置
 DEBUG_SHOW_RAW_LINE = False
 
@@ -110,12 +113,17 @@ def list_serial_ports():
     return [port.device for port in ports]
 
 
-def main():
-    # 1. 选择串口
+def get_serial_config():
+    """默认自动配置；仅在 -p 模式下进入交互配置。"""
     ports = list_serial_ports()
     if not ports:
         print(f"{Fore.RED}No serial ports found!")
-        return
+        return None
+
+    interactive_mode = "-p" in sys.argv[1:]
+
+    if not interactive_mode:
+        return ports[0], DEFAULT_BAUD_RATE, DEBUG_SHOW_RAW_LINE
 
     print("Available Ports:")
     for i, p in enumerate(ports):
@@ -124,18 +132,30 @@ def main():
     try:
         idx = int(input("Select Port Index: "))
         port_name = ports[idx]
-        baud_rate = int(input("Baudrate: ") or "115200")
+        baud_rate = int(input(f"Baudrate [{DEFAULT_BAUD_RATE}]: ") or str(DEFAULT_BAUD_RATE))
 
         debug_input = input("Show raw/debug binary data? (y/N): ").strip().lower()
-        if debug_input == "y":
-            global DEBUG_SHOW_RAW_LINE
-            DEBUG_SHOW_RAW_LINE = True
-        else:
-            DEBUG_SHOW_RAW_LINE = False
+        debug_show_raw_line = debug_input == "y"
+        return port_name, baud_rate, debug_show_raw_line
 
     except:
         print("Invalid selection.")
+        return None
+
+
+def main():
+    global DEBUG_SHOW_RAW_LINE
+
+    serial_config = get_serial_config()
+    if serial_config is None:
         return
+
+    port_name, baud_rate, DEBUG_SHOW_RAW_LINE = serial_config
+
+    if "-p" not in sys.argv[1:]:
+        print(
+            f"{Fore.CYAN}[System] Auto selected {port_name} @ {baud_rate}, raw/debug output: {'ON' if DEBUG_SHOW_RAW_LINE else 'OFF'}"
+        )
 
     # 启动 TCP 转发线程
     forwarder = DataForwarder()


### PR DESCRIPTION
## Summary
本次 small-update 主要聚焦系统稳定性与调试流程优化，同时改进日志路由脚本的默认使用体验。

## Changes
- 调整 RTOS 关键任务优先级为更均衡配置，降低任务抢占导致的时序波动风险
- 在 System 运行流程中增加“退出调试态”检测逻辑（基于连续 delta_time 判定），并补充状态标志 `out_from_debugmode`
- 暂时关闭 `BspLog_RecvCMD()` 调用，减少 RTT 命令处理对主流程的潜在干扰
- 更新 `log_router.py`：
  - 增加默认波特率 `921600`
  - 支持默认自动选串口
  - 仅在 `-p` 参数下进入交互式串口配置

## Impact
- 提升系统主循环稳定性与可预期性
- 降低日志工具使用门槛，便于快速接入与调试
