### PR TITLE
fix：修复Monitor监视变量时发送数据错误

### DIFF
--- a/ReactorLibs/FrameComponets/Sys/Monitor/Monitor.cpp
+++ b/ReactorLibs/FrameComponets/Sys/Monitor/Monitor.cpp
@@ -30,8 +30,8 @@ void Monitor::TrackLog()
     if (track_count < 1)   return; // 没有跟踪变量，直接返回
 
     memset(track_send_buf, 0, 64);
-    track_send_buf[0] = '[';
-    size_t used_bytes = 1;
+    //track_send_buf[0] = '[';
+    size_t used_bytes = 0;
 
     for(int i = 0; i < track_count; i++)
     {
@@ -108,8 +108,8 @@ void Monitor::TrackLogJustFloat()
     // 你的 Monitor.hpp 里定义了 byte vofa_buf[64]，这里正好用上
     // 8个变量 * 4字节 + 4字节帧尾 = 36字节，64字节足够了
     memset(vofa_buf, 0, 64);
-    vofa_buf[0] = '[';
-    size_t used_bytes = 1;
+    // vofa_buf[0] = '[';
+    size_t used_bytes = 0;
 
     for(int i = 0; i < track_count; i++)
     {


### PR DESCRIPTION
修复使用firewater，Justfloat两协议时的发送数据错误，以符合对应的协议，修改后可在上位机正确读到反馈数据
