### PR TITLE
为BspUart新增了中断发送功能

### DIFF
--- a/ReactorLibs/FrameComponets/Bsps/bsp_system/bsp_halport.cpp
+++ b/ReactorLibs/FrameComponets/Bsps/bsp_system/bsp_halport.cpp
@@ -6,6 +6,7 @@ namespace Hardware
     float MainFreq_MHz = 72.0f;
 
     bool RTTLogAtUart = false;
+    bool RTTLogUartItrp = false;
 
     /**-----    配置CAN总线     -----**/
     BSP::CAN::CanID hcan_main = nullptr;
@@ -16,6 +17,7 @@ namespace Hardware
     BSP::UART::UartID huart_farcon = nullptr;
     BSP::UART::UartID huart_odom = nullptr;
     BSP::UART::UartID huart_other = nullptr;
+    BSP::UART::UartID huart_log = nullptr;     
 
     /**-----    配置SPI总线    -----**/
     BSP::SPI::SpiID spi_main_bus = nullptr;

--- a/ReactorLibs/FrameComponets/Bsps/bsp_system/bsp_halport.hpp
+++ b/ReactorLibs/FrameComponets/Bsps/bsp_system/bsp_halport.hpp
@@ -90,8 +90,7 @@ namespace Hardware
 
     /// @note 如果本标志位被激活，日志会被同步发送到 UART_HOST
     extern bool RTTLogAtUart;
-    
-    
+    extern bool RTTLogUartItrp;
 
     /***---------------     框架定时器    ---------------***/
     /// @brief WS2812灯带定时器

--- a/ReactorLibs/FrameComponets/Bsps/bsp_system/bsp_hardware.hpp
+++ b/ReactorLibs/FrameComponets/Bsps/bsp_system/bsp_hardware.hpp
@@ -14,6 +14,8 @@ namespace Hardware
     extern BSP::UART::UartID huart_odom;
     /// @brief 其他串口
     extern BSP::UART::UartID huart_other;
+    /// @brief 日志串口
+    extern BSP::UART::UartID huart_log;     // 专用日志串口（如果需要）
 
     /***---------------     框架CAN    ---------------***/
     /// @brief 框架所用CAN句柄

--- a/ReactorLibs/FrameComponets/Bsps/log/bsp_log.cpp
+++ b/ReactorLibs/FrameComponets/Bsps/log/bsp_log.cpp
@@ -53,7 +53,14 @@ void BspLog_Init(void)
     // 如果确定使用 UART 输出日志，可以在这里获取 huart_host 的句柄
     if (Hardware::RTTLogAtUart)
     {
-        uart_log_handler = BSP::UART::Apply(Hardware::huart_host);
+        if (Hardware::RTTLogUartItrp)
+        {
+            uart_log_handler = BSP::UART::Apply(Hardware::huart_log, BSP::UART::TxMode::Interrupt);
+        }
+        else
+        {
+            uart_log_handler = BSP::UART::Apply(Hardware::huart_log);
+        }
     }
 }
 

--- a/ReactorLibs/FrameComponets/Bsps/uart/README.md
+++ b/ReactorLibs/FrameComponets/Bsps/uart/README.md
@@ -1,9 +1,9 @@
 # BSP UART 库使用说明
 
-`bsp_uart` 是一个基于 STM32 HAL 库封装的串口通信库，通过 **DMA + FIFO** 实现高效发送，并利用 **IDLE (空闲中断) + DMA** 实现变长数据接收。
+`bsp_uart` 是一个基于 STM32 HAL 库封装的串口通信库，通过 **DMA/中断 + FIFO** 实现异步发送，并利用 **IDLE (空闲中断) + DMA** 实现变长数据接收。
 
 ## 核心功能
-- **异步发送**：由 DMA 自动发送，数据先写入 FIFO 以解决连续调用 DMA 时数据的截断问题，不阻塞应用层。
+- **异步发送**：数据先写入 FIFO，再由 DMA 或 UART TX 中断发送，不阻塞应用层。
 - **高效接收**：自动触发 IDLE 中断，支持变长数据包接收。
 - **解耦设计**：使用 `UartID` (不透明指针) 替代 HAL 句柄，减少头文件依赖。
 
@@ -23,10 +23,18 @@
 
 // 示例：获取工控机通信串口的句柄
 auto uart_handler = BSP::UART::Apply(Hardware::huart_host);
+
+```
+如果某个串口没有配置 `DMA`，也可以使用 **中断模式** 发送  
+使用前，请确认已经在 CubeMX 中正确配置了对应串口的全局中断
+
+```cpp
+// 没有配置 TX DMA 的串口，可使用 TX 中断发送
+auto uart_it_handler = BSP::UART::Apply(Hardware::huart_other, BSP::UART::TxMode::Interrupt);
 ```
 
 ### 发送数据 (`Transmit`)
-直接调用 `Transmit` 即可。库会自动处理 FIFO 缓冲和 DMA 启动。
+直接调用 `Transmit` 即可。库会自动处理 FIFO 缓冲，并按实例发送模式启动 DMA 或 TX 中断。
 ```cpp
 uint8_t data[] = {0x01, 0x02, 0x03};
 uart_handler.Transmit(data, sizeof(data));
@@ -34,6 +42,9 @@ uart_handler.Transmit(data, sizeof(data));
 
 ### 注册并接收数据 (`RegisterRx`)
 定义一个回调函数，并将其注册到串口句柄中。
+
+> 截止 2026-5-4，接收回调仍只支持 DMA 模式
+
 ```cpp
 // 定义回调函数
 void MyRxCallback(BSP::UART::UartID id, uint8_t *rxData, uint8_t size) {
@@ -49,10 +60,13 @@ uart_handler.RegisterRx(64, MyRxCallback);
 ## 注意事项
 
 - **单实例原则**：每个硬件串口只能申请一个 `Instance`。
+- **发送模式**：默认使用 `TxMode::Dma`；同一串口首次 `Apply` 时确定发送模式，后续重复申请不会动态切换。
 - **回调限制**：每个实例仅允许注册 **一次** 接收回调。
 - **缓冲区大小**：
   - 发送 FIFO 默认为 `2048` 字节 (`BSP_UART_TX_BUF_SIZE`)。
   - 接收单次最大包长不应超过 `64` 字节 (`BSP_UART_RX_BUF_SIZE`)。
 - **常见问题**：
   - 若日志出现 `[Bsp] UART Tx FIFO Full`，说明发送频率过高或波特率过低。
-  - 确保已经在 `CubeMX` 中开启了对应串口的 **DMA 接收** 和 **全局中断**。
+  - DMA 发送模式需要开启对应串口的 **TX DMA**。
+  - `TxMode::Interrupt` 发送模式需要开启对应串口的 **USART 全局中断**。
+  - 接收功能仍需要开启对应串口的 **DMA 接收** 和 **USART 全局中断**。

--- a/ReactorLibs/FrameComponets/Bsps/uart/bsp_uart.cpp
+++ b/ReactorLibs/FrameComponets/Bsps/uart/bsp_uart.cpp
@@ -57,9 +57,17 @@ static Instance *FindInstByHuart(UART_HandleTypeDef *huart)
 }
 
 /**
- * @brief 申请一个 UART 实例句柄
+ * @brief 申请一个默认 DMA 发送模式的 UART 实例句柄
  */
 Handler BSP::UART::Apply(UartID id, const char* file, int line)
+{
+    return Apply(id, TxMode::Dma, file, line);
+}
+
+/**
+ * @brief 按指定发送模式申请一个 UART 实例句柄
+ */
+Handler BSP::UART::Apply(UartID id, TxMode tx_mode, const char* file, int line)
 {
     UART_HandleTypeDef *huart = ToHalHandle(id);
     
@@ -76,6 +84,11 @@ Handler BSP::UART::Apply(UartID id, const char* file, int line)
     // 如果已经存在，直接返回对应的 Handler
     if (exist_inst != nullptr)
     {
+        // 同一硬件串口的发送模式以首次申请为准，避免运行期切换破坏状态机
+        if (exist_inst->GetTxMode() != tx_mode)
+        {
+            BspLog_LogWarning("[Bsp] Uart TxMode Already Fixed, Ignore New TxMode! [%s:%d]\n", GetFileName(file), line);
+        }
         return Handler(exist_inst);
     }
 
@@ -87,7 +100,7 @@ Handler BSP::UART::Apply(UartID id, const char* file, int line)
     }
     
     // 初始化新实例
-    insts[instance_count].Init(id);
+    insts[instance_count].Init(id, tx_mode);
 
     // 返回新实例的 Handler
     Instance *new_inst = &insts[instance_count];
@@ -135,17 +148,18 @@ Instance::Instance()
     Init(nullptr);
 }
 
-Instance::Instance(UartID id)
+Instance::Instance(UartID id, TxMode tx_mode)
 {
-    Init(id);
+    Init(id, tx_mode);
 }
 
 /**
  * @brief 初始化实例，重置所有成员变量
  */
-void Instance::Init(UartID in_id)
+void Instance::Init(UartID in_id, TxMode tx_mode)
 {
     this->id = in_id;
+    this->tx_mode_ = tx_mode;
     this->rx_callback = nullptr;
     this->rx_setlen_ = 0;
     this->rx_registered_ = 0;
@@ -163,6 +177,14 @@ void Instance::Init(UartID in_id)
 bool Instance::IsUsing(UartID target_id) const
 {
     return (this->id != nullptr && this->id == target_id);
+}
+
+/**
+ * @brief 获取实例首次申请时固定的发送模式
+ */
+TxMode Instance::GetTxMode() const
+{
+    return this->tx_mode_;
 }
 
 void Instance::Transmit(const uint8_t *data, uint16_t len)
@@ -202,8 +224,8 @@ void Instance::Transmit(const uint8_t *data, uint16_t len)
         this->tx_fifo_.head = next_head;
     }
 
-    // 启用DMA发送（如果当前DMA空闲）
-    this->TryStartTxDMA();
+    // 按当前模式启动发送（如果当前发送空闲）
+    this->TryStartTx();
 }
 
 /**
@@ -271,6 +293,20 @@ bool Instance::RegisterRx(uint16_t rx_setlen, RxCallback rx_callback, const char
 }
 
 /**
+ * @brief 按当前发送模式尝试启动发送
+ */
+void Instance::TryStartTx()
+{
+    if (this->tx_mode_ == TxMode::Interrupt)
+    {
+        this->TryStartTxIT();
+        return;
+    }
+
+    this->TryStartTxDMA();
+}
+
+/**
  * @brief 尝试启动DMA发送，如果当前DMA空闲且FIFO中有数据
  */
 void Instance::TryStartTxDMA()
@@ -322,7 +358,55 @@ void Instance::TryStartTxDMA()
 }
 
 /**
- * @brief HAL UART DMA发送完成回调入口，更新FIFO状态并尝试发送剩余数据
+ * @brief 尝试启动TX中断发送，如果当前发送空闲且FIFO中有数据
+ */
+void Instance::TryStartTxIT()
+{
+    if (this->id == nullptr)
+    {
+        BspLog_LogWarning("[Bsp] Unable to Start Tx IT, Empty Instance!\n");
+        return;
+    }
+
+    if (this->tx_fifo_.is_busy != 0)
+    {
+        // 当前发送未完成，等待完成回调继续推进FIFO
+        return;
+    }
+
+    if (this->tx_fifo_.head == this->tx_fifo_.tail)
+    {
+        // FIFO为空，无需启动新的发送事务
+        return;
+    }
+
+    // 计算本次最大连续发送长度，避免一次发送跨越环形缓冲区尾部
+    uint16_t send_len = 0;
+    if (this->tx_fifo_.head > this->tx_fifo_.tail)
+    {
+        send_len = this->tx_fifo_.head - this->tx_fifo_.tail;
+    }
+    else
+    {
+        send_len = BSP_UART_TX_BUF_SIZE - this->tx_fifo_.tail;
+    }
+
+    // 启动UART TX中断发送，完成后由HAL_UART_TxCpltCallback继续推进
+    this->tx_fifo_.sending_len = send_len;
+
+    if (HAL_UART_Transmit_IT(ToHalHandle(this->id), &this->tx_fifo_.buffer[this->tx_fifo_.tail], send_len) == HAL_OK)
+    {
+        this->tx_fifo_.is_busy = 1;
+    }
+    else
+    {
+        BspLog_LogError("[Bsp] Failed to Start HAL_Tx_IT!\n");
+        this->tx_fifo_.sending_len = 0;
+    }
+}
+
+/**
+ * @brief HAL UART 发送完成回调入口，更新FIFO状态并尝试发送剩余数据
  */
 void Instance::OnTxCplt()
 {
@@ -344,28 +428,9 @@ void Instance::OnTxCplt()
         return;
     }
 
-    // 计算下一段连续数据长度（处理环形回绕）
-    uint16_t send_len = 0;
-    if (this->tx_fifo_.head > this->tx_fifo_.tail)
-    {
-        send_len = this->tx_fifo_.head - this->tx_fifo_.tail;
-    }
-    else
-    {
-        send_len = BSP_UART_TX_BUF_SIZE - this->tx_fifo_.tail;
-    }
-
-    // 启动下一段DMA发送
-    this->tx_fifo_.sending_len = send_len;
-    if (HAL_UART_Transmit_DMA(ToHalHandle(this->id), &this->tx_fifo_.buffer[this->tx_fifo_.tail], send_len) == HAL_OK)
-    {
-        this->tx_fifo_.is_busy = 1;
-    }
-    else
-    {
-        this->tx_fifo_.sending_len = 0;
-        this->tx_fifo_.is_busy = 0;
-    }
+    // 释放忙标志，让统一入口按当前模式启动下一段发送
+    this->tx_fifo_.is_busy = 0;
+    this->TryStartTx();
 }
 
 void Instance::OnRxEvent(uint16_t size)

--- a/ReactorLibs/FrameComponets/Bsps/uart/bsp_uart.hpp
+++ b/ReactorLibs/FrameComponets/Bsps/uart/bsp_uart.hpp
@@ -28,11 +28,19 @@ namespace BSP
         // 接收回调函数类型
         using RxCallback = void (*)(UartID id, uint8_t *rxData, uint8_t size);
 
+        /// @brief UART 发送后端模式
+        enum class TxMode : uint8_t
+        {
+            Dma,       ///< 使用 DMA + FIFO 异步发送
+            Interrupt  ///< 使用 UART TX 中断 + FIFO 异步发送
+        };
+
         ::__UART_HandleTypeDef* ToHalHandle(UartID id);
         UartID ToUartID(::__UART_HandleTypeDef* huart);
 
         /// @brief 申请一个 UART 实例
         Handler Apply(UartID id, const char* file = __builtin_FILE(), int line = __builtin_LINE());
+        Handler Apply(UartID id, TxMode tx_mode, const char* file = __builtin_FILE(), int line = __builtin_LINE());
 
         class Handler
         {
@@ -62,10 +70,10 @@ namespace BSP
 
             /// @brief 构造函数
             /// @param id 目标硬件串口层的不透明句柄
-            explicit Instance(UartID id);
+            explicit Instance(UartID id, TxMode tx_mode = TxMode::Dma);
 
             /// @brief 重置并初始化实例
-            void Init(UartID id);
+            void Init(UartID id, TxMode tx_mode = TxMode::Dma);
 
             /// @brief 发送串口数据（带缓冲，默认DMA）
             void Transmit(const uint8_t *data, uint16_t len);
@@ -75,7 +83,10 @@ namespace BSP
 
             bool IsUsing(UartID target_id) const;
 
-            /// @brief HAL UART DMA发送完成回调入口
+            /// @brief 获取本实例发送模式
+            TxMode GetTxMode() const;
+
+            /// @brief HAL UART 发送完成回调入口（DMA/IT共用）
             void OnTxCplt();
 
             /// @brief HAL UART DMA接收事件回调入口
@@ -98,8 +109,16 @@ namespace BSP
                 volatile uint8_t is_busy;
             };
 
+            /// @brief 按发送模式分流启动发送
+            void TryStartTx();
+
+            /// @brief 尝试启动 DMA 发送
             void TryStartTxDMA();
 
+            /// @brief 尝试启动 TX 中断发送
+            void TryStartTxIT();
+
+            TxMode tx_mode_;
             TxFIFO tx_fifo_;
             uint8_t rx_buffer_[BSP_UART_RX_BUF_SIZE];
             uint16_t rx_setlen_;

--- a/ReactorLibs/FrameComponets/Sys/StateCore/StateCore.cpp
+++ b/ReactorLibs/FrameComponets/Sys/StateCore/StateCore.cpp
@@ -95,7 +95,7 @@ void StateCore::Run()
 
     // 执行 `当前状态图` 的 `对应状态`的 状态函数
     StateGraph& graph = *graphs[at_graph_id];
-    StateBlock& state = graph.current_state;
+    StateBlock* state = graph.current_state;
 
     // 执行当前状态图的全局状态函数
     if (graph.GlobalAction != nullptr) graph.GlobalAction(this);
@@ -105,11 +105,15 @@ void StateCore::Run()
      * 所以后面应该会加入 在中间打断动作 的机制（确保动作打断是经过作者设计的）
      * @warning 只有非空状态函数才会被执行 
      */
-    if (state.StateAction != nullptr) state.StateAction(this);
+    if (state->StateAction != nullptr) state->StateAction(this);
 
     // 进行状态转移
-    graph.executor_at_id = state.Transition();
-    graph.current_state = graph.states[graph.executor_at_id];
+    uint8_t next_id = state->Transition();
+    if (next_id != graph.executor_at_id) 
+    {
+        graph.executor_at_id = next_id;
+        graph.current_state = &graph.states[next_id]; // 指针重定向
+    }
 }
 
 void StateCore::Enable(uint8_t first_graph)


### PR DESCRIPTION
# 主要改动
- BspUart新增中断发送功能
- 将 `huart_log` 独立于了 `huart_host`，现在日志不一定要发到工控机上
- 重新修复了StateCore状态转移存在问题的BUG